### PR TITLE
Fix rspec regression introduced in commit b7d8a59e021a8f1224afd490afd617de950b423d

### DIFF
--- a/lib/test_construct/rspec_integration.rb
+++ b/lib/test_construct/rspec_integration.rb
@@ -36,13 +36,13 @@ RSpec.configure do |config|
   config.include TestConstruct::Helpers
   config.include TestConstruct::RSpecIntegration
 
-  config.before :each do
+  config.before :each do |example|
     next unless test_construct_enabled?(example)
     options = test_construct_options(example)
     example.metadata[:construct] = setup_construct(options)
   end
 
-  config.after :each do
+  config.after :each do |example|
     next unless test_construct_enabled?(example)
     options = test_construct_options(example)
     teardown_construct(

--- a/test/rspec_integration_test.rb
+++ b/test/rspec_integration_test.rb
@@ -4,11 +4,13 @@ def unindent(s)
   s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, '')
 end
 
+# Test harness for test_construct rspec integration
+#
 class RspecIntegrationTest < Minitest::Test
   include TestConstruct::Helpers
 
   def teardown
-    Dir.chdir File.expand_path("../..", __FILE__)
+    Dir.chdir File.expand_path('../..', __FILE__)
     TestConstruct.destroy_all!
   end
 
@@ -19,7 +21,7 @@ class RspecIntegrationTest < Minitest::Test
         spec_file_name = 'test_construct_spec.rb'
         construct.file(spec_file_name, unindent(<<-RSPEC))
           require 'test_construct/rspec_integration'
-            
+
           describe 'test_construct', test_construct: true do
             it 'should execute a test that always passes' do
               expect(1).to eq(1)

--- a/test/rspec_integration_test.rb
+++ b/test/rspec_integration_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+def unindent(s)
+  s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, '')
+end
+
+class RspecIntegrationTest < Minitest::Test
+  include TestConstruct::Helpers
+
+  def teardown
+    Dir.chdir File.expand_path("../..", __FILE__)
+    TestConstruct.destroy_all!
+  end
+
+  testing 'using the test_construct' do
+    test 'using test_construct does not cause an error' do
+      lib_path = File.realpath('lib')
+      within_construct do |construct|
+        spec_file_name = 'test_construct_spec.rb'
+        construct.file(spec_file_name, unindent(<<-RSPEC))
+          require 'test_construct/rspec_integration'
+            
+          describe 'test_construct', test_construct: true do
+            it 'should execute a test that always passes' do
+              expect(1).to eq(1)
+            end
+          end
+        RSPEC
+        output = `rspec -I '#{lib_path}' #{spec_file_name}`
+        assert $CHILD_STATUS.success?, output
+      end
+    end
+  end
+end


### PR DESCRIPTION
When trying to use test_construct with rspec, I discovered that the change made to lib/test_construct/rspec_integration.rb in commit  https://github.com/bhb/test_construct/commit/b7d8a59e021a8f1224afd490afd617de950b423d made test_construct rspec integration not function at all.  

I added a Minitest test with a rudimentary test case to test rspec integration within test/rspec_integration_test.rb. While I only tested what was needed to get rspec integration working again, RspecIntegrationTest could serve as a point for more exhaustive tests of rspec integration.