### PR TITLE
pathname_extensions.rb - File.open windows

### DIFF
--- a/lib/test_construct/pathname_extensions.rb
+++ b/lib/test_construct/pathname_extensions.rb
@@ -17,7 +17,8 @@ module TestConstruct
     def file(filepath, contents = nil, &block)
       path = (self+filepath)
       path.dirname.mkpath
-      File.open(path,'w') do |f|
+      mode = RUBY_PLATFORM =~ /mingw|mswin/ ? 'wb:UTF-8' : 'w'
+      File.open(path, mode) do |f|
         if(block)
           if(block.arity==1)
             block.call(f)


### PR DESCRIPTION
Windows file IO will normally use \r\n for line endings.

Changes to use standard \n, along with UTF-8.