### PR TITLE
Fix compatibility with Mocha 2.0+

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'minitest'
 require "minitest/autorun"
 
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'test_construct'
 
 class Minitest::Test


### PR DESCRIPTION
Replace `mocha/setup` by `mocha/minitest`. The former was deprecated by Mocha 1.10 [[1]] and removed in Mocha 2.0 [[2]].


[1]: https://github.com/freerange/mocha/commit/36adf880a0b9302fb5e770161c2e962e7e20fe71
[2]: https://github.com/freerange/mocha/commit/642a0ff4f3806ae0a625c50c14a6a39702735e51